### PR TITLE
Nullable DateTime converter fixed

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -272,7 +272,7 @@ jobs:
     needs: [determine-version, build-windows, build-linux]
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) ||
+      (github.event_name == 'push' && (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/'))) ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     permissions:

--- a/VictoryRoad.UI/Converters/DateTimeToDateTimeOffsetConverter.cs
+++ b/VictoryRoad.UI/Converters/DateTimeToDateTimeOffsetConverter.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace VictoryRoad.UI.Converters;
+
+public class DateTimeToDateTimeOffsetConverter : IValueConverter
+{
+    public static readonly DateTimeToDateTimeOffsetConverter Instance = new();
+    
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is DateTime dateTime)
+        {
+            return new DateTimeOffset(dateTime);
+        }
+        return null;
+    }
+    
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is DateTimeOffset dateTimeOffset)
+        {
+            var dateTime = dateTimeOffset.DateTime;
+            
+            // Validate birth date is not too recent (must be at least 5 years ago)
+            if (dateTime > DateTime.Now.AddYears(-5))
+            {
+                // Return the maximum allowed date instead of the invalid date
+                return DateTime.Now.AddYears(-5);
+            }
+            
+            // Validate birth date is not in the future
+            if (dateTime > DateTime.Now)
+            {
+                return DateTime.Now;
+            }
+            
+            return dateTime;
+        }
+        return null;
+    }
+}

--- a/VictoryRoad.UI/MainWindow.axaml
+++ b/VictoryRoad.UI/MainWindow.axaml
@@ -4,6 +4,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:VictoryRoad.UI.ViewModels"
         xmlns:conv="using:VictoryRoad.UI.Converters"
+        xmlns:sys="clr-namespace:System;assembly=System.Runtime"
         mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
         x:Class="VictoryRoad.UI.MainWindow"
         x:DataType="vm:MainWindowViewModel"
@@ -47,7 +48,7 @@
             
             <StackPanel Grid.Row="0" Grid.Column="2" Margin="5,0,0,10">
                 <TextBlock Text="Date:" Margin="0,0,0,5"/>
-                <DatePicker SelectedDate="{Binding Date}"/>
+                <DatePicker SelectedDate="{Binding Date, Converter={x:Static conv:DateTimeToDateTimeOffsetConverter.Instance}}"/>
             </StackPanel>
             
             <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,10,0">


### PR DESCRIPTION
This pull request introduces validation and conversion logic for birth dates in the UI, ensuring users can only select valid dates and automatically updating the Pokémon TCG age division based on the selected date. It adds a new value converter, updates the binding in the main window, and refines the view model to handle validation and division assignment.

**Birth date validation and conversion:**

* Added a new `DateTimeToDateTimeOffsetConverter` in `VictoryRoad.UI/Converters/DateTimeToDateTimeOffsetConverter.cs`, which converts between `DateTime` and `DateTimeOffset`, and enforces birth date validation rules (must be at least 5 years ago and not in the future).
* Updated the `DatePicker` binding in `VictoryRoad.UI/MainWindow.axaml` to use the new converter for the `Date` property, ensuring proper type conversion and validation.
* Added the necessary namespace import for system types in `VictoryRoad.UI/MainWindow.axaml`.

**View model logic improvements:**

* Enhanced the `Date` property setter in `VictoryRoad.UI/ViewModels/MainWindowViewModel.cs` to validate the birth date and provide user feedback if the date is invalid.
* Implemented `UpdateDivisionFromBirthDate()` in the view model, which calculates the user's Pokémon TCG division (Junior, Senior, Masters) based on their age at the start of the current championship season.

**Workflow update:**

* Modified the build-and-release workflow in `.github/workflows/build-and-release.yml` to allow releases from both the `main` branch and tags, improving release flexibility.